### PR TITLE
Make migration workflow functional on Github UI

### DIFF
--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -34,19 +34,19 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
+          echo ${{ env.GH_TOKEN2 }} > token.sh
+          gh auth login --with-token < token.sh
+          gh auth setup-git
+        env:
+          GH_TOKEN2: ${{ secrets.GH }}
 
       - name: Raise Products
         run: |
           export engineUrl=${{ inputs.engineUrl }}
           export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           echo "workDir=$(pwd)" >> $GITHUB_ENV
-          echo ${{ env.GH_TOKEN2 }} > token.sh
-          gh auth login --with-token < token.sh
-          gh auth setup-git
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash
-        env:
-          GH_TOKEN2: ${{ secrets.GH }}
 
       - name: Show migrated repositories
         if: ${{ inputs.product == '' }} 

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -16,6 +16,7 @@ on:
         required: true
         default: 'https://developer.axonivy.com/permalink/12.0.0/axonivy-engine.zip'
 
+
 jobs:
   raise-products:
     runs-on: ubuntu-latest
@@ -29,10 +30,6 @@ jobs:
           distribution: 'temurin'
           java-version: 21
 
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - name: Configure Git
         run: |
           git config --global user.email "actions@github.com"
@@ -43,10 +40,13 @@ jobs:
           export engineUrl=${{ inputs.engineUrl }}
           export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           echo "workDir=$(pwd)" >> $GITHUB_ENV
+          echo ${{ env.GH_TOKEN2 }} > token.sh
+          gh auth login --with-token < token.sh
+          gh auth setup-git
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN2: ${{ secrets.GH }}
 
       - name: Show migrated repositories
         if: ${{ inputs.product == '' }} 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,31 @@ In the `github repository name` input field enter the name of the repository you
 If the input field is empty, the script will update all repositories from `axonivy-market` organization
 with some exceptions (see "raise-all-market-products.sh" at [line 27](https://github.com/axonivy-market/update-scripts/blob/a5375f8a4026475a281a3f445d28ab37d82ec45d/raise-all-market-products.sh#L27) 
 and [line 6](https://github.com/axonivy-market/update-scripts/blob/a5375f8a4026475a281a3f445d28ab37d82ec45d/raise-all-market-products.sh#L6)).
+
+### Permissions
+
+In order to run the `raise-products.yml` workflow, permissions throughout the axonivy-market org must be granted.
+
+#### Lease
+If the token is no longer valid, generate a token as follows:
+
+- Navigate into your profile > Settings > [Developer Settings](https://github.com/settings/tokens?type=beta) > Personal Access Tokens > Fine-Grained > Generate New
+
+    - Resource Owner = axonivy-market
+    - Expiration = 30 days
+    - Permissions that must granted:
+      ```
+      Contents=read/write
+      Metadata=read/only (default)
+      Pull Requests=read/write
+      Workflows=read/write
+      ```
+    - Click: Generate Secret
+    - Copy the secret to your clipboard
+
+- Go into the [Settings](https://github.com/axonivy-market/market-up2date-keeper/settings/secrets/actions) tab of market-up2date-keeper: Security > Actions
+    - Edit the secret called `GH`
+    - Paste your personal token and save
+
+- Ready: now launch your workflow 🚀️
+

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -55,8 +55,6 @@ migrateRepo() {
   cd $DIR
 }
 
-echo "running as $ACTOR or gh $GITHUB_ACTOR"
-
 repo_name=$2
 if [ -z "$repo_name" ]; then
   migrateListOfRepos

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -55,6 +55,8 @@ migrateRepo() {
   cd $DIR
 }
 
+echo "running as $ACTOR or gh $GITHUB_ACTOR"
+
 repo_name=$2
 if [ -z "$repo_name" ]; then
   migrateListOfRepos

--- a/repo-collector.sh
+++ b/repo-collector.sh
@@ -10,9 +10,8 @@ ignored_repos=(
 org=axonivy-market
 
 githubRepos() {
-  gh auth status
   ghApi="orgs/${org}/repos?per_page=100"
-  gh api https://api.github.com/${ghApi}
+  curl https://api.github.com/${ghApi}
 }
 
 githubReposC(){

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -20,7 +20,7 @@ checkRepoExists() {
 
 cloneRepo() {
   if ! [ -d "${repo}" ]; then
-    gh repo clone "${clone_url}"
+    gh repo clone "${repo_url}"
   fi
 }
 

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -48,7 +48,7 @@ push() {
   else
     echo "Pushing changes of ${repo_name}"
     git push --set-upstream origin $branch
-    gh pr create --title "Migrate to 12.0 :camel:" --body "A friendly conversion provided by market-up2date-keeper :robot: :handshake: "
+    gh pr create --title "Migrate to 12.0 :camel:" --assignee "$GITHUB_ACTOR" --body "A friendly conversion provided by market-up2date-keeper :robot: :handshake: "
     echo "${repo_url}" >> ${workDir}/migrated-repos.txt
   fi
 }


### PR DESCRIPTION
allow github worklfow to update any repository throughout the axonivy-market org.

it will assign PRs created to the user that triggered the workflow, so you won't forget to merge or handle problems as you should get a notification once the PR is ready.
 still the commits are done by the generic "actions" user. I think this is nice to separate technical changes from those of real users.

here's are examples created by running this workflow: 
https://github.com/axonivy-market/metaproc-connector/pull/25
https://github.com/axonivy-market/srf-weather-connector/pull/27
https://github.com/axonivy-market/excel-connector/pull/54
![image](https://github.com/user-attachments/assets/b9f7efb1-81e1-44b3-9b4b-3ebe69167332)


