### PR TITLE
Central sonatype migration :camel: :building_construction: :cocktail: :palm_tree: :sunglasses:  

### DIFF
--- a/jobs/createPrsToSwitchSnapshotRepo.sh
+++ b/jobs/createPrsToSwitchSnapshotRepo.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+BRANCH="central-sonatype-migration"
+TITLE="Migrate to new central.sonatype Portal URI :camel:"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${DIR}/../repo-changer.sh"
+
+# new snapshots of the project-build-plugin and web-tester are only published under the new Central Portal URI:
+updateSnapshotSource() {
+  echo "updating ${repo_name}"
+  where="**/pom.xml"
+  oldRepo="https://oss.sonatype.org/content/repositories/snapshots"
+  newRepo="https://central.sonatype.com/repository/maven-snapshots"
+  sed -i -E "s|<url>${oldRepo}</url>|<url>${newRepo}</url>|g" $where
+}
+
+changeRepos 'updateSnapshotSource'

--- a/repo-changer.sh
+++ b/repo-changer.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$DIR/repo-collector.sh"
+
+if [ -z "${BRANCH}" ]; then
+  echo "no BRANCH variable defined"
+  exit 123
+fi
+if [ -z "${TITLE}" ]; then
+  echo "no TITLE variable defined"
+  exit 124
+fi
+if [ -z "${BODY}" ]; then
+  BODY=$TITLE
+fi
+
+migrated_repos=()
+
+pushAndCreatePR() {
+  has_unpushed_commits=$(git log --branches --not --remotes)
+  if [ -z "$has_unpushed_commits" ]; then
+    echo "No changes to push for ${repo_name}"
+  else
+    echo "Pushing changes of ${repo_name}"
+    git push --set-upstream origin $BRANCH
+    gh pr create\
+      --title "$TITLE"\
+      --assignee "$GITHUB_ACTOR"\
+      --body "$BODY"
+    migrated_repos+=("$repo_url")
+  fi
+}
+
+changeRepos() {
+  changeAction="$1"
+  if [ -z "$changeAction" ]; then
+    echo "changeRepos was called without a parameter to define the 'change' function name"
+    exit 125
+  fi
+  collectRepos | while read -r repo_name; do
+    changeSingleRepo "$repo_name"
+  done
+  echo "migrated: ${migrated_repos[@]}"
+}
+
+changeSingleRepo() {
+  repo_name="$1"
+  # Ensure repo name has no carriage return characters
+  repo_name=$(echo "$repo_name" | sed 's/\r//g')
+  if [[ " ${ignored_repos[@]} " =~ " ${repo_name} " ]]; then
+    echo "Ignoring repo ${repo_name}"
+    return
+  fi
+
+  echo "Clone repo ${repo_name}"
+  gh repo clone "git@github.com:${org}/${repo_name}.git"
+
+  cd "${repo_name}"
+  git switch -c $BRANCH
+
+  # run
+  "${changeAction}"
+
+  git add .
+  git commit -m "$TITLE"
+
+  pushAndCreatePR
+  cd ..
+}


### PR DESCRIPTION
The project-build-plugin and web-tester are now publishing SNAPSHOTS to a new repository. This scripts migrates the market.org towards that end.

:heavy_check_mark: the 'repo-changer.sh' is another approach to automate 99% of the repo-walkthrough ... now those who wan't to roll-out a heavy change, only need to implement the real change of a single repo :rocket: 