### PR TITLE
Feature/marp 4326 automate market extension migration end2end

### DIFF
--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Raise Products
         run: |
+          export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
           export migrationBranch=${{ inputs.migrationBranch }}

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -16,15 +16,23 @@ on:
         description: 'Axon Ivy Engine URL'
         required: true
         default: 'https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip'
-      createReleaseBranch:
-        description: 'Create a release branch to backup source code before raising. Only needed when raising from LTS to the next dev version.'
+      migrateToLatestLTSVersion:
+        description: 'Migrate current source code to the latest LTS version (e.g. 14.0.0). If the value is false (migrate to latest dev version e.g. 13.0, 15.0,...), the source code will be clone into below releaseBranch before raising the version.'
         required: false
         type: boolean
         default: false
       releaseBranch:
-        description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "createReleaseBranch" is checked.'
+        description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "migrateToLatestLTSVersion" is false.'
         required: false
         default: 'release/14.0'
+      buildPluginVersion:
+        description: 'Version of the build plugin'
+        required: false
+        default: ''
+      testerVersion:
+        description: 'Version of the tester plugin'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -56,7 +64,10 @@ jobs:
       - name: Raise Products
         run: |
           export engineUrl=${{ inputs.engineUrl }}
-          export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
+          export releaseBranch=${{ inputs.migrateToLatestLTSVersion == false && '' || inputs.releaseBranch }}
+          export migrateToLatestLTSVersion=${{ inputs.migrateToLatestLTSVersion }}
+          export buildPluginVersion=${{ inputs.buildPluginVersion }}
+          export testerVersion=${{ inputs.testerVersion }}
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -56,7 +56,6 @@ jobs:
         run: |
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
-          export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -7,7 +7,7 @@ on:
       product:
         description: 'github repository name (e.g. alfresco-connector) or blank for all projects of the axonivy-market org'
         required: false
-        default: 'migrate-14.0'
+        default: ''
       version:
         description: 'Snaphsot version to raise (e.g. "14.0.0-SNAPSHOT")'
         required: true

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -33,8 +33,6 @@ on:
         description: 'Java version to use for the migration (e.g. "25")'
         required: false
         default: '25'
-      
-
 
 permissions:
   contents: read
@@ -65,7 +63,6 @@ jobs:
 
       - name: Raise Products
         run: |
-          export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
           export migrationBranch=${{ inputs.migrationBranch }}

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -25,10 +25,6 @@ on:
         description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "createReleaseBranch" is true.'
         required: false
         default: 'release/13.0'
-      buildPluginVersion:
-        description: 'Version of the build plugin'
-        required: false
-        default: ''
 
 
 permissions:

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -9,26 +9,31 @@ on:
         required: false
         default: ''
       version:
-        description: 'Snaphsot version to raise (e.g. "13.2.0-SNAPSHOT")'
+        description: 'Snapshot version to raise (e.g. "14.0.0-SNAPSHOT")'
         required: true
-        default: '13.2.0-SNAPSHOT'
+        default: '14.0.0-SNAPSHOT'
       engineUrl:
         description: 'Axon Ivy Engine URL'
         required: true
-        default: 'https://developer.axonivy.com/permalink/13.2/axonivy-engine.zip'
+        default: 'https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip'
+      migrationBranch:
+        description: 'Branch to use for the migrating to the target branch. If not specified, the name will be "migrate-to-{version}" (e.g. "migrate-to-14.0.0-SNAPSHOT")'
+        required: false
+        default: ''
       createReleaseBranch:
-        description: 'Whether to create a release branch (e.g. "release/13.2") from the main branch. If false, the main branch will be migrated directly.'
+        description: 'Whether to create a release branch (e.g. "release/13.0") from the main branch. If false, the main branch will be migrated directly.'
         required: false
         type: boolean
         default: false
       releaseBranch:
-        description: 'Name of the release branch to create (e.g. "release/13.2"). Only used when "createReleaseBranch" is true.'
+        description: 'Name of the release branch to create (e.g. "release/13.0"). Only used when "createReleaseBranch" is true.'
         required: false
-        default: 'release/12'
+        default: 'release/13'
       javaVersion:
         description: 'Java version to use for the migration (e.g. "25")'
         required: false
         default: '25'
+      
 
 
 permissions:
@@ -46,7 +51,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: ${{ inputs.javaVersion }}
 
       - name: Configure Git
         run: |
@@ -62,7 +67,7 @@ jobs:
         run: |
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
-          export IVY_JAVA_HOME=$JAVA_HOME_21_X64
+          export migrationBranch=${{ inputs.migrationBranch }}
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -62,7 +62,6 @@ jobs:
         run: |
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
-          export buildPluginVersion=${{ inputs.buildPluginVersion }}
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -28,7 +28,7 @@ on:
       releaseBranch:
         description: 'Name of the release branch to create (e.g. "release/13.0"). Only used when "createReleaseBranch" is true.'
         required: false
-        default: 'release/13'
+        default: 'release/13.0'
       javaVersion:
         description: 'Java version to use for the migration (e.g. "25")'
         required: false

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -8,17 +8,22 @@ on:
         description: 'github repository name (e.g. alfresco-connector) or blank for all projects of the axonivy-market org'
         required: false
       version:
-        description: 'Snaphsot version to raise (e.g. "13.1.1-SNAPSHOT")'
+        description: 'Snaphsot version to raise (e.g. "14.0.0-SNAPSHOT")'
         required: true
-        default: '13.1.1-SNAPSHOT'
+        default: '14.0.0-SNAPSHOT'
       engineUrl:
         description: 'Axon Ivy Engine URL'
         required: true
-        default: 'https://developer.axonivy.com/permalink/13.1.1/axonivy-engine.zip'
+        default: 'https://developer.axonivy.com/permalink/14.0.0/axonivy-engine.zip'
+      createReleaseBranch:
+        description: 'Create a release branch to backup source code before raising. Only needed when raising from LTS to the next dev version.'
+        required: false
+        type: boolean
+        default: false
       releaseBranch:
-        description: 'Create a release branch to backup source code of the current version (e.g. "release/12.0"). This release branch should only be created for LTS versions.'
-        required: true
-        default: 'release/12.0'
+        description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "createReleaseBranch" is checked.'
+        required: false
+        default: 'release/14.0'
 
 permissions:
   contents: read
@@ -35,7 +40,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
 
       - name: Configure Git
         run: |
@@ -50,7 +55,7 @@ jobs:
       - name: Raise Products
         run: |
           export engineUrl=${{ inputs.engineUrl }}
-          export releaseBranch=${{ inputs.releaseBranch }}
+          export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
           export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -24,7 +24,7 @@ on:
       releaseBranch:
         description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "createReleaseBranch" is true.'
         required: false
-        default: 'release/14.0'
+        default: 'release/13.0'
       buildPluginVersion:
         description: 'Version of the build plugin'
         required: false

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -7,6 +7,7 @@ on:
       product:
         description: 'github repository name (e.g. alfresco-connector) or blank for all projects of the axonivy-market org'
         required: false
+        default: 'migrate-14.0'
       version:
         description: 'Snaphsot version to raise (e.g. "14.0.0-SNAPSHOT")'
         required: true
@@ -14,7 +15,7 @@ on:
       engineUrl:
         description: 'Axon Ivy Engine URL'
         required: true
-        default: 'https://developer.axonivy.com/permalink/14.0.0/axonivy-engine.zip'
+        default: 'https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip'
       createReleaseBranch:
         description: 'Create a release branch to backup source code before raising. Only needed when raising from LTS to the next dev version.'
         required: false

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -9,22 +9,26 @@ on:
         required: false
         default: ''
       version:
-        description: 'Snaphsot version to raise (e.g. "14.0.0-SNAPSHOT")'
+        description: 'Snaphsot version to raise (e.g. "13.2.0-SNAPSHOT")'
         required: true
-        default: '14.0.0-SNAPSHOT'
+        default: '13.2.0-SNAPSHOT'
       engineUrl:
         description: 'Axon Ivy Engine URL'
         required: true
-        default: 'https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip'
+        default: 'https://developer.axonivy.com/permalink/13.2/axonivy-engine.zip'
       createReleaseBranch:
-        description: 'Whether to create a release branch (e.g. "release/14.0") from the main branch. If false, the main branch will be migrated directly.'
+        description: 'Whether to create a release branch (e.g. "release/13.2") from the main branch. If false, the main branch will be migrated directly.'
         required: false
         type: boolean
         default: false
       releaseBranch:
-        description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "createReleaseBranch" is true.'
+        description: 'Name of the release branch to create (e.g. "release/13.2"). Only used when "createReleaseBranch" is true.'
         required: false
-        default: 'release/13.0'
+        default: 'release/12'
+      javaVersion:
+        description: 'Java version to use for the migration (e.g. "25")'
+        required: false
+        default: '25'
 
 
 permissions:
@@ -42,7 +46,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 25
+          java-version: 21
 
       - name: Configure Git
         run: |
@@ -58,6 +62,7 @@ jobs:
         run: |
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
+          export IVY_JAVA_HOME=$JAVA_HOME_21_X64
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -16,23 +16,20 @@ on:
         description: 'Axon Ivy Engine URL'
         required: true
         default: 'https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip'
-      migrateToLatestLTSVersion:
-        description: 'Migrate current source code to the latest LTS version (e.g. 14.0.0). If the value is false (migrate to latest dev version e.g. 13.0, 15.0,...), the source code will be clone into below releaseBranch before raising the version.'
+      createReleaseBranch:
+        description: 'Whether to create a release branch (e.g. "release/14.0") from the main branch. If false, the main branch will be migrated directly.'
         required: false
         type: boolean
         default: false
       releaseBranch:
-        description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "migrateToLatestLTSVersion" is false.'
+        description: 'Name of the release branch to create (e.g. "release/14.0"). Only used when "createReleaseBranch" is true.'
         required: false
         default: 'release/14.0'
       buildPluginVersion:
         description: 'Version of the build plugin'
         required: false
         default: ''
-      testerVersion:
-        description: 'Version of the tester plugin'
-        required: false
-        default: ''
+
 
 permissions:
   contents: read
@@ -64,10 +61,8 @@ jobs:
       - name: Raise Products
         run: |
           export engineUrl=${{ inputs.engineUrl }}
-          export releaseBranch=${{ inputs.migrateToLatestLTSVersion == false && '' || inputs.releaseBranch }}
-          export migrateToLatestLTSVersion=${{ inputs.migrateToLatestLTSVersion }}
+          export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
           export buildPluginVersion=${{ inputs.buildPluginVersion }}
-          export testerVersion=${{ inputs.testerVersion }}
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/.github/workflows/replace-text.yml
+++ b/.github/workflows/replace-text.yml
@@ -19,6 +19,11 @@ on:
         description: 'Replacement text/string (e.g. org.apache.commons.lang3.StringUtils)'
         required: true
         type: string
+      fileExtension:
+        description: 'File extension to search/replace (e.g. java, xml, classpath)'
+        required: false
+        default: 'java'
+        type: string
 
 permissions:
   contents: read
@@ -49,4 +54,5 @@ jobs:
             "${{ inputs.product }}" \
             "${{ inputs.branch }}" \
             "${{ inputs.oldText }}" \
-            "${{ inputs.newText }}"
+            "${{ inputs.newText }}" \
+            "${{ inputs.fileExtension }}"

--- a/.github/workflows/replace-text.yml
+++ b/.github/workflows/replace-text.yml
@@ -1,0 +1,52 @@
+name: Replace text
+
+on:
+  workflow_dispatch:
+    inputs:
+      product:
+        description: 'GitHub repository name (e.g. alfresco-connector) or blank for all projects of the axonivy-market org'
+        required: false
+        default: ''
+      branch:
+        description: 'Branch name (e.g. master, release/12.0, ...)'
+        required: true
+        type: string
+      oldText:
+        description: 'Text/string to replace in all Java source files (e.g. org.apache.commons.lang.StringUtils)'
+        required: true
+        type: string
+      newText:
+        description: 'Replacement text/string (e.g. org.apache.commons.lang3.StringUtils)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+
+jobs:
+  replace-text:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout market-up2date-keeper
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          echo ${{ env.GH_TOKEN2 }} > token.sh
+          gh auth login --with-token < token.sh
+          gh auth setup-git
+        env:
+          GH_TOKEN2: ${{ secrets.GH }}
+
+      - name: Replace text using script
+        run: |
+          chmod +x replace-text.sh
+          ./replace-text.sh \
+            "${{ inputs.product }}" \
+            "${{ inputs.branch }}" \
+            "${{ inputs.oldText }}" \
+            "${{ inputs.newText }}"

--- a/.github/workflows/update-missing-dependency.yml
+++ b/.github/workflows/update-missing-dependency.yml
@@ -1,0 +1,68 @@
+name: Update dependency
+
+on:
+  workflow_dispatch:
+    inputs:
+      product:
+        description: 'github repository name (e.g. alfresco-connector) or blank for all projects of the axonivy-market org'
+        required: false
+        default: ''
+      branch:
+        description: 'Branch name (e.g. master, release/12.0, ...)'
+        required: true
+        type: string
+      module:
+        description: 'Module name (e.g. idp-connector-demo)'
+        required: true
+        type: string
+      groupId:
+        description: 'Group ID of the dependency (e.g. com.axonivy.market)'
+        required: true
+        type: string
+      artifactId:
+        description: 'Artifact ID of the dependency (e.g. market-core)'
+        required: true
+        type: string
+      version:
+        description: 'Version of the dependency (e.g. 1.0.0)'
+        type: string
+
+permissions:
+  contents: read
+
+
+jobs:
+  update-lib:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout market-up2date-keeper
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          echo ${{ env.GH_TOKEN2 }} > token.sh
+          gh auth login --with-token < token.sh
+          gh auth setup-git
+        env:
+          GH_TOKEN2: ${{ secrets.GH }}
+
+      - name: Update dependency using script
+        run: |
+          cd market-up2date-keeper
+          chmod +x update-dependency.sh
+          ./update-dependency.sh \
+            "${{ inputs.product }}" \
+            "${{ inputs.branch }}" \
+            "${{ inputs.module }}" \
+            "${{ inputs.groupId }}" \
+            "${{ inputs.artifactId }}" \
+            "${{ inputs.version }}"

--- a/.github/workflows/update-missing-dependency.yml
+++ b/.github/workflows/update-missing-dependency.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Update dependency using script
         run: |
-          cd market-up2date-keeper
           chmod +x update-dependency.sh
           ./update-dependency.sh \
             "${{ inputs.product }}" \

--- a/jobs/createPrsToGenerateReleaseDrafterWorkflow.sh
+++ b/jobs/createPrsToGenerateReleaseDrafterWorkflow.sh
@@ -60,13 +60,7 @@ githubRepos() {
 }
 
 collectRepos() {
-  githubRepos | 
-    jq -r '.[] | 
-    select(.archived == false) | 
-    select(.is_template == false) | 
-    select(.default_branch == "master") | 
-    select(.language != null) | 
-      .name' | sed 's/\r//g'
+  printf "%s\n" "adobe-acrobat-sign-connector" "google-translate-connector"
 }
 
 create_label_if_not_exists() {

--- a/jobs/createPrsToGenerateReleaseDrafterWorkflow.sh
+++ b/jobs/createPrsToGenerateReleaseDrafterWorkflow.sh
@@ -60,7 +60,13 @@ githubRepos() {
 }
 
 collectRepos() {
-  printf "%s\n" "adobe-acrobat-sign-connector" "google-translate-connector"
+  githubRepos | 
+    jq -r '.[] | 
+    select(.archived == false) | 
+    select(.is_template == false) | 
+    select(.default_branch == "master") | 
+    select(.language != null) | 
+      .name' | sed 's/\r//g'
 }
 
 create_label_if_not_exists() {

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -26,7 +26,7 @@ artifactVersion() {
   testerVersion="$3"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
-    updatebuildPluginVersion $buildPluginVersion
+    updateBuildPluginVersion $buildPluginVersion
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
@@ -34,7 +34,7 @@ artifactVersion() {
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    updatebuildPluginVersion $buildPluginVersion
+    updateBuildPluginVersion $buildPluginVersion
     updateTesterVersion $testerVersion
     mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -10,12 +10,13 @@ artifactVersion() {
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    updateMvnProperty
   fi
   # update version in pom.xml
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    mvn -f $d -B versions:set -DnewVersion=$convert_to_version -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f $d -B versions:set -DnewVersion=$newVersion -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -6,10 +6,14 @@ updateMvnProperty() {
 
 artifactVersion() {
   newVersion="$1"
-  oldVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null)
-  echo "Updating maven version from ${oldVersion} to ${newVersion}"
-  # if root pom.xml exists
+  # if root pom.xml exists, update all declared modules in one pass
   if [ -f "pom.xml" ]; then
-    mvn -B versions:set -DoldVersion=${oldVersion} -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
   fi
+  # update version in pom.xml
+  # loop through all folders
+  for d in */ ; do
+    echo "Updating $d"
+    mvn -f "$d" -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false
+  done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -15,7 +15,7 @@ artifactVersion() {
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    mvn -f $d -B versions:set -DnewVersion=$newVersion -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -13,9 +13,10 @@ artifactVersion() {
   fi
   # update version in pom.xml
   # loop through all folders
+  shopt -s nullglob
   for d in */ ; do
     echo "Updating $d"
-    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    mvn -f "$d" -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f "$d" -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -4,13 +4,39 @@ updateMvnProperty() {
   mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true -DprocessAllModules
 }
 
+updateBuildPluginVersion() {
+  pluginVersion="$1"
+   if [ -n "$pluginVersion" ]; then
+    echo "Updating build plugin version to ${pluginVersion}"
+    updateMvnProperty "project.build.plugin.version" $pluginVersion
+  fi
+}
+
+updateTesterVersion() {
+  testerVersion="$1"
+   if [ -n "$testerVersion" ]; then
+    echo "Updating tester version to ${testerVersion}"
+    updateMvnProperty "tester.version" $testerVersion
+  fi
+}
+
 artifactVersion() {
   newVersion="$1"
+  buildPluginVersion="$2"
+  testerVersion="$3"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
-    echo "Updating artifact version to ${newVersion}"
+    updatebuildPluginVersion $buildPluginVersion
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
-    echo "Updating dependencies to latest versions"
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
+  # update version in pom.xml
+  # loop through all folders
+  for d in */ ; do
+    echo "Updating $d"
+    updatebuildPluginVersion $buildPluginVersion
+    updateTesterVersion $testerVersion
+    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+  done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -6,8 +6,10 @@ updateMvnProperty() {
 
 artifactVersion() {
   newVersion="$1"
+  oldVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null)
+  echo "Updating maven version from ${oldVersion} to ${newVersion}"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
-    mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -B versions:set -DoldVersion=${oldVersion} -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
   fi
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -20,6 +20,11 @@ updateTesterVersion() {
   fi
 }
 
+currentVersion() {
+  local pomDir="${1:-.}"
+  mvn -f "$pomDir" -q -DforceStdout -Dexpression=project.version --non-recursive help:evaluate 2>/dev/null
+}
+
 artifactVersion() {
   newVersion="$1"
   buildPluginVersion="$2"
@@ -27,7 +32,8 @@ artifactVersion() {
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
     updateBuildPluginVersion $buildPluginVersion
-    mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    oldVersion=$(currentVersion .)
+    mvn -B versions:set "-DnewVersion=${newVersion}" "-DoldVersion=${oldVersion}" -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
   # update version in pom.xml
@@ -36,7 +42,8 @@ artifactVersion() {
     echo "Updating $d"
     updateBuildPluginVersion $buildPluginVersion
     updateTesterVersion $testerVersion
-    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    oldVersion=$(currentVersion "$d")
+    mvn -f "$d" -B versions:set "-DnewVersion=${newVersion}" "-DoldVersion=${oldVersion}" -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f "$d" -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -9,14 +9,11 @@ artifactVersion() {
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
-    updateMvnProperty
   fi
   # update version in pom.xml
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    mvn -f $d -B versions:set -DnewVersion=$newVersion -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    mvn -f "$d" -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -10,10 +10,4 @@ artifactVersion() {
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
   fi
-  # update version in pom.xml
-  # loop through all folders
-  for d in */ ; do
-    echo "Updating $d"
-    mvn -f "$d" -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
-  done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -5,15 +5,18 @@ updateMvnProperty() {
 }
 
 artifactVersion() {
+  # if root pom.xml exists
   newVersion="$1"
   # if root pom.xml exists, update all declared modules in one pass
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
   # update version in pom.xml
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    mvn -f "$d" -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false
+    mvn -f $d -B versions:set -DnewVersion=$convert_to_version -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -11,11 +11,4 @@ artifactVersion() {
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
-  # update version in pom.xml
-  # loop through all folders
-  for d in */ ; do
-    echo "Updating $d"
-    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
-  done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -5,9 +5,8 @@ updateMvnProperty() {
 }
 
 artifactVersion() {
-  # if root pom.xml exists
   newVersion="$1"
-  # if root pom.xml exists, update all declared modules in one pass
+  # if root pom.xml exists
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
@@ -16,7 +15,7 @@ artifactVersion() {
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    mvn -f $d -B versions:set -DnewVersion=$convert_to_version -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f $d -B versions:set -DnewVersion=$newVersion -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -3,11 +3,30 @@ updateMvnProperty() {
   value="$2"
   mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true -DprocessAllModules
 }
+removeMvnProperty() {
+  name="$1"
+
+  # Remove from root pom.xml
+  if [ -f "pom.xml" ]; then
+    echo "Removing property '$name' from root pom.xml"
+    sed -i "/<${name}>.*<\/${name}>/d" pom.xml
+  fi
+
+  # Remove from all child pom.xml files
+  for d in */ ; do
+    if [ -f "${d}pom.xml" ]; then
+      echo "Removing property '$name' from ${d}pom.xml"
+      sed -i "/<${name}>.*<\/${name}>/d" "${d}pom.xml"
+    fi
+  done
+}
 
 artifactVersion() {
   newVersion="$1"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
+    removeMvnProperty "project.build.plugin.versions"
+    removeMvnProperty "tester.version"
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -10,6 +10,7 @@ artifactVersion() {
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    updateMvnProperty
   fi
   # update version in pom.xml
   # loop through all folders

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -4,30 +4,10 @@ updateMvnProperty() {
   mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true -DprocessAllModules
 }
 
-updateBuildPluginVersion() {
-  pluginVersion="$1"
-   if [ -n "$pluginVersion" ]; then
-    echo "Updating build plugin version to ${pluginVersion}"
-    updateMvnProperty "project.build.plugin.version" $pluginVersion
-  fi
-}
-
-updateTesterVersion() {
-  testerVersion="$1"
-   if [ -n "$testerVersion" ]; then
-    echo "Updating tester version to ${testerVersion}"
-    updateMvnProperty "tester.version" $testerVersion
-  fi
-}
-
 artifactVersion() {
   newVersion="$1"
-  buildPluginVersion="$2"
-  testerVersion="$3"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
-    updateBuildPluginVersion $buildPluginVersion
-    updateTesterVersion $testerVersion
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -8,7 +8,9 @@ artifactVersion() {
   newVersion="$1"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
+    echo "Updating artifact version to ${newVersion}"
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    echo "Updating dependencies to latest versions"
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -3,30 +3,11 @@ updateMvnProperty() {
   value="$2"
   mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true -DprocessAllModules
 }
-removeMvnProperty() {
-  name="$1"
-
-  # Remove from root pom.xml
-  if [ -f "pom.xml" ]; then
-    echo "Removing property '$name' from root pom.xml"
-    sed -i "/<${name}>.*<\/${name}>/d" pom.xml
-  fi
-
-  # Remove from all child pom.xml files
-  for d in */ ; do
-    if [ -f "${d}pom.xml" ]; then
-      echo "Removing property '$name' from ${d}pom.xml"
-      sed -i "/<${name}>.*<\/${name}>/d" "${d}pom.xml"
-    fi
-  done
-}
 
 artifactVersion() {
   newVersion="$1"
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
-    removeMvnProperty "project.build.plugin.versions"
-    removeMvnProperty "tester.version"
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -1,7 +1,7 @@
 updateMvnProperty() {
   name="$1"
   value="$2"
-  mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true
+  mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true -DprocessAllModules
 }
 
 updateBuildPluginVersion() {
@@ -28,16 +28,14 @@ artifactVersion() {
   if [ -f "pom.xml" ]; then
     updateBuildPluginVersion $buildPluginVersion
     updateTesterVersion $testerVersion
-    mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false
-    mvn -B versions:use-latest-versions -DgenerateBackupPoms=false
+    mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   fi
   # update version in pom.xml
   # loop through all folders
   for d in */ ; do
     echo "Updating $d"
-    updateBuildPluginVersion $buildPluginVersion
-    updateTesterVersion $testerVersion
-    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false
-    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false
+    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
+    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
   done
 }

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -10,7 +10,6 @@ artifactVersion() {
   if [ -f "pom.xml" ]; then
     mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false -DprocessAllModules=true
     mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
-    updateMvnProperty
   fi
   # update version in pom.xml
   # loop through all folders

--- a/maven-migrator.sh
+++ b/maven-migrator.sh
@@ -1,7 +1,7 @@
 updateMvnProperty() {
   name="$1"
   value="$2"
-  mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true -DprocessAllModules
+  mvn -B versions:set-property versions:commit "-Dproperty=${name}" "-DnewVersion=${value}" -DallowSnapshots=true
 }
 
 updateBuildPluginVersion() {
@@ -20,11 +20,6 @@ updateTesterVersion() {
   fi
 }
 
-currentVersion() {
-  local pomDir="${1:-.}"
-  mvn -f "$pomDir" -q -DforceStdout -Dexpression=project.version --non-recursive help:evaluate 2>/dev/null
-}
-
 artifactVersion() {
   newVersion="$1"
   buildPluginVersion="$2"
@@ -32,9 +27,9 @@ artifactVersion() {
   # if root pom.xml exists
   if [ -f "pom.xml" ]; then
     updateBuildPluginVersion $buildPluginVersion
-    oldVersion=$(currentVersion .)
-    mvn -B versions:set "-DnewVersion=${newVersion}" "-DoldVersion=${oldVersion}" -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    updateTesterVersion $testerVersion
+    mvn -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false
+    mvn -B versions:use-latest-versions -DgenerateBackupPoms=false
   fi
   # update version in pom.xml
   # loop through all folders
@@ -42,8 +37,7 @@ artifactVersion() {
     echo "Updating $d"
     updateBuildPluginVersion $buildPluginVersion
     updateTesterVersion $testerVersion
-    oldVersion=$(currentVersion "$d")
-    mvn -f "$d" -B versions:set "-DnewVersion=${newVersion}" "-DoldVersion=${oldVersion}" -DgenerateBackupPoms=false -DprocessAllModules=true
-    mvn -f "$d" -B versions:use-latest-versions -DgenerateBackupPoms=false -DprocessAllModules
+    mvn -f $d -B versions:set -DnewVersion=${newVersion} -DgenerateBackupPoms=false
+    mvn -f $d -B versions:use-latest-versions -DgenerateBackupPoms=false
   done
 }

--- a/project-migrator.sh
+++ b/project-migrator.sh
@@ -4,7 +4,7 @@ if [ -z "$workDir" ]; then
   workDir=$(mktemp -d -t projectConvertXXX)
 fi
 if [ -z "$engineUrl" ]; then
-  engineUrl="https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip"
+  engineUrl="https://developer.axonivy.com/permalink/13.2/axonivy-engine.zip"
 fi
 
 downloadEngine(){
@@ -18,8 +18,8 @@ downloadEngine(){
 }
 
 raiseProject() {
-  gitDir=$(pwd)
-  gitName=$(basename ${gitDir})
+  local gitDir=$(pwd)
+  local gitName=$(basename ${gitDir})
   echo "Searching projects in ${gitDir}"
   projects=()
   for ivyPref in $(find ${gitDir} -name "ch.ivyteam.ivy.designer.prefs"); do

--- a/project-migrator.sh
+++ b/project-migrator.sh
@@ -4,7 +4,7 @@ if [ -z "$workDir" ]; then
   workDir=$(mktemp -d -t projectConvertXXX)
 fi
 if [ -z "$engineUrl" ]; then
-  engineUrl="https://developer.axonivy.com/permalink/14.0.0/axonivy-engine.zip"
+  engineUrl="https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip"
 fi
 
 downloadEngine(){

--- a/project-migrator.sh
+++ b/project-migrator.sh
@@ -4,7 +4,7 @@ if [ -z "$workDir" ]; then
   workDir=$(mktemp -d -t projectConvertXXX)
 fi
 if [ -z "$engineUrl" ]; then
-  engineUrl="https://developer.axonivy.com/permalink/13.1.1/axonivy-engine.zip"
+  engineUrl="https://developer.axonivy.com/permalink/14.0.0/axonivy-engine.zip"
 fi
 
 downloadEngine(){

--- a/project-migrator.sh
+++ b/project-migrator.sh
@@ -4,7 +4,7 @@ if [ -z "$workDir" ]; then
   workDir=$(mktemp -d -t projectConvertXXX)
 fi
 if [ -z "$engineUrl" ]; then
-  engineUrl="https://developer.axonivy.com/permalink/13.2/axonivy-engine.zip"
+  engineUrl="https://developer.axonivy.com/permalink/sprint/axonivy-engine.zip"
 fi
 
 downloadEngine(){

--- a/project-migrator.sh
+++ b/project-migrator.sh
@@ -19,7 +19,6 @@ downloadEngine(){
 
 raiseProject() {
   local gitDir=$(pwd)
-  local gitName=$(basename ${gitDir})
   echo "Searching projects in ${gitDir}"
   projects=()
   for ivyPref in $(find ${gitDir} -name "ch.ivyteam.ivy.designer.prefs"); do

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -17,12 +17,12 @@ fi
 
 convert_to_version=$1
 if [ -z "$convert_to_version" ]; then
-  echo "Missing target version parameter e.g 13.2.0-SNAPSHOT"
+  echo "Missing target version parameter e.g 14.0.0-SNAPSHOT"
   exit 1
 fi
 
 if [[ ! $convert_to_version == *-SNAPSHOT ]]; then
-  echo "Version must be SNAPSHOT e.g 13.2.0-SNAPSHOT"
+  echo "Version must be SNAPSHOT e.g 14.0.0-SNAPSHOT"
   exit 1
 fi
 

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -17,12 +17,12 @@ fi
 
 convert_to_version=$1
 if [ -z "$convert_to_version" ]; then
-  echo "Missing target version parameter e.g 13.1.1-SNAPSHOT"
+  echo "Missing target version parameter e.g 14.0.0-SNAPSHOT"
   exit 1
 fi
 
 if [[ ! $convert_to_version == *-SNAPSHOT ]]; then
-  echo "Version must be SNAPSHOT e.g 13.1.1-SNAPSHOT"
+  echo "Version must be SNAPSHOT e.g 14.0.0-SNAPSHOT"
   exit 1
 fi
 

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -36,43 +36,9 @@ showMigratedRepos() {
 }
 
 migrateListOfRepos() {
-  printf "%s\n" \
-  "adobe-acrobat-sign-connector" \
-  "google-translate-connector" \
-  "stateful-datatable" \
-  "intellix-connector" \
-  "email-encryption" \
-  "express-importer" \
-  "cronjob" \
-  "kafka-connector" \
-  "master-detail" \
-  "sbb-connector" \
-  "srf-weather-connector" \
-  "metaproc-connector" \
-  "docker-connector" \
-  "graphql-demo" \
-  "threema-connector" \
-  "excel-importer" \
-  "salesforce-connector" \
-  "ups-connector" \
-  "open-weather-connector" \
-  "process-inspector" \
-  "mattermost-connector" \
-  "rtf-factory" \
-  "jsf-formarchive-util" \
-  "process-miner-viewer" \
-  "ai-assistant" \
-  "skribble-connector" \
-  "vertexai-google" \
-  "S4HANA-connector" \
-  "asana-connector" \
-  "gdpr-utils" \
-  "snowflake-connector" \
-  "keycloak-connector" \
-  "coffee-machine-connector" \
-  "case-mail-component-connector" |
+  collectRepos |
   while read repo_name; do
-  migrateRepo "$repo_name"
+    migrateRepo $repo_name
   done
   showMigratedRepos
 }

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -36,9 +36,43 @@ showMigratedRepos() {
 }
 
 migrateListOfRepos() {
-  collectRepos |
+  printf "%s\n" \
+  "adobe-acrobat-sign-connector" \
+  "google-translate-connector" \
+  "stateful-datatable" \
+  "intellix-connector" \
+  "email-encryption" \
+  "express-importer" \
+  "cronjob" \
+  "kafka-connector" \
+  "master-detail" \
+  "sbb-connector" \
+  "srf-weather-connector" \
+  "metaproc-connector" \
+  "docker-connector" \
+  "graphql-demo" \
+  "threema-connector" \
+  "excel-importer" \
+  "salesforce-connector" \
+  "ups-connector" \
+  "open-weather-connector" \
+  "process-inspector" \
+  "mattermost-connector" \
+  "rtf-factory" \
+  "jsf-formarchive-util" \
+  "process-miner-viewer" \
+  "ai-assistant" \
+  "skribble-connector" \
+  "vertexai-google" \
+  "S4HANA-connector" \
+  "asana-connector" \
+  "gdpr-utils" \
+  "snowflake-connector" \
+  "keycloak-connector" \
+  "coffee-machine-connector" \
+  "case-mail-component-connector" |
   while read repo_name; do
-    migrateRepo $repo_name
+  migrateRepo "$repo_name"
   done
   showMigratedRepos
 }

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -17,12 +17,12 @@ fi
 
 convert_to_version=$1
 if [ -z "$convert_to_version" ]; then
-  echo "Missing target version parameter e.g 14.0.0-SNAPSHOT"
+  echo "Missing target version parameter e.g 13.2.0-SNAPSHOT"
   exit 1
 fi
 
 if [[ ! $convert_to_version == *-SNAPSHOT ]]; then
-  echo "Version must be SNAPSHOT e.g 14.0.0-SNAPSHOT"
+  echo "Version must be SNAPSHOT e.g 13.2.0-SNAPSHOT"
   exit 1
 fi
 

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -36,9 +36,9 @@ showMigratedRepos() {
 }
 
 migrateListOfRepos() {
-  collectRepos |
+  printf "%s\n" "adobe-acrobat-sign-connector" "google-translate-connector" |
   while read repo_name; do
-    migrateRepo $repo_name
+    migrateRepo "$repo_name"
   done
   showMigratedRepos
 }

--- a/raise-all-market-products.sh
+++ b/raise-all-market-products.sh
@@ -36,9 +36,9 @@ showMigratedRepos() {
 }
 
 migrateListOfRepos() {
-  printf "%s\n" "adobe-acrobat-sign-connector" "google-translate-connector" |
+  collectRepos |
   while read repo_name; do
-    migrateRepo "$repo_name"
+    migrateRepo $repo_name
   done
   showMigratedRepos
 }

--- a/replace-text.sh
+++ b/replace-text.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Usage: replace-text.sh [products] <branch> <oldText> <newText>
+#
+# Parameters:
+#   products - (Optional) Single product name, comma-separated list, or empty to use all repos
+#   branch   - Branch name (e.g. master, release/12.0)
+#   oldText  - Text/string to replace in all Java source files
+#              (e.g. org.apache.commons.lang.StringUtils)
+#   newText  - Replacement text/string
+#              (e.g. org.apache.commons.lang3.StringUtils)
+#
+# Examples:
+#   replace-text.sh alfresco-connector master \
+#       "org.apache.commons.lang.StringUtils" \
+#       "org.apache.commons.lang3.StringUtils"
+#
+#   replace-text.sh "" master \
+#       "org.apache.commons.lang.StringUtils" \
+#       "org.apache.commons.lang3.StringUtils"
+#
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. ${DIR}/repo-collector.sh
+
+if [ $# -lt 4 ]; then
+  echo "Usage: $0 [products] <branch> <oldText> <newText>"
+  echo "Example: $0 'alfresco-connector' master 'org.apache.commons.lang.StringUtils' 'org.apache.commons.lang3.StringUtils'"
+  echo "Example (all repos): $0 '' master 'org.apache.commons.lang.StringUtils' 'org.apache.commons.lang3.StringUtils'"
+  exit 1
+fi
+
+products=$1
+branch=$2
+oldText=$3
+newText=$4
+
+# Auto-collect repos if empty
+if [ -z "$products" ]; then
+  products=$(collectRepos | tr '\n' ',' | sed 's/,$//')
+fi
+
+ORG="axonivy-market"
+WORK_DIR=$(mktemp -d -t replace-import-XXXXXX)
+# trap "rm -rf ${WORK_DIR}" EXIT
+
+replaceInProduct() {
+  local product=$1
+  local repo_url="https://github.com/${ORG}/${product}.git"
+
+  echo "→ ${product}"
+  echo "  URL: ${repo_url}"
+  echo "  Branch: ${branch}"
+  cd "${WORK_DIR}"
+
+  if ! git clone -b "${branch}" "${repo_url}" "${product}" 2>/dev/null; then
+    echo "  ❌ Clone failed"
+    return 1
+  fi
+
+  cd "${product}"
+  echo "  Cloned to: $(pwd)"
+
+  # Count files containing the old text before replacement
+  local match_count
+  match_count=$(grep -rl --include="*.java" "${oldText}" . 2>/dev/null | wc -l)
+
+  if [ "${match_count}" -eq 0 ]; then
+    echo "  ℹ No occurrences of '${oldText}' found — skipping"
+    return 0
+  fi
+
+  echo "  Found '${oldText}' in ${match_count} file(s) — replacing..."
+
+  # Replace all occurrences in Java source files
+  find . -name "*.java" -exec sed -i "s|${oldText}|${newText}|g" {} +
+
+  echo "  Checking for changes in: $(pwd)"
+  if git diff --quiet; then
+    echo "  ℹ No changes detected after replacement"
+    return 0
+  fi
+
+  echo "  Changed files:"
+  git diff --name-only
+
+  git add .
+  git commit -m "Replace text: ${oldText} -> ${newText}"
+  echo "  Commit: $(git log -1 --oneline)"
+
+  if ! git push origin "HEAD:${branch}" 2>/dev/null; then
+    echo "  ❌ Push failed"
+    return 1
+  fi
+
+  echo "  ✓ Replaced and pushed"
+}
+
+echo "Replacing: '${oldText}'"
+echo "With:      '${newText}'"
+echo "Branch:    ${branch}"
+echo ""
+
+IFS=',' read -ra product_list <<< "$products"
+for product in "${product_list[@]}"; do
+  product=$(echo "$product" | xargs)
+  [ -z "$product" ] && continue
+  replaceInProduct "$product" || true
+done

--- a/replace-text.sh
+++ b/replace-text.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 #
-# Usage: replace-text.sh [products] <branch> <oldText> <newText>
+# Usage: replace-text.sh [products] <branch> <oldText> <newText> [fileExtension]
 #
 # Parameters:
-#   products - (Optional) Single product name, comma-separated list, or empty to use all repos
-#   branch   - Branch name (e.g. master, release/12.0)
-#   oldText  - Text/string to replace in matched source files
-#              (e.g. org.apache.commons.lang.StringUtils)
-#   newText  - Replacement text/string
-#              (e.g. org.apache.commons.lang3.StringUtils)
+#   products      - (Optional) Single product name, comma-separated list, or empty to use all repos
+#   branch        - Branch name (e.g. master, release/12.0)
+#   oldText       - Text/string to replace in matched source files
+#                   (e.g. org.apache.commons.lang.StringUtils)
+#   newText       - Replacement text/string
+#                   (e.g. org.apache.commons.lang3.StringUtils)
+#   fileExtension - (Optional) File extension to search/replace (e.g. java, xml, classpath). Default: java
 #
 # Examples:
 #   replace-text.sh alfresco-connector master \
@@ -63,6 +64,14 @@ replaceInProduct() {
 
   cd "${product}"
   echo "  Cloned to: $(pwd)"
+
+  # Check if any files with the extension exist
+  local file_count
+  file_count=$(find . -name "*.${fileExtension}" 2>/dev/null | wc -l)
+  if [ "${file_count}" -eq 0 ]; then
+    echo "  ℹ No *.${fileExtension} files found in $(pwd) — skipping"
+    return 0
+  fi
 
   # Count files containing the old text before replacement
   local match_count

--- a/replace-text.sh
+++ b/replace-text.sh
@@ -5,7 +5,7 @@
 # Parameters:
 #   products - (Optional) Single product name, comma-separated list, or empty to use all repos
 #   branch   - Branch name (e.g. master, release/12.0)
-#   oldText  - Text/string to replace in all Java source files
+#   oldText  - Text/string to replace in matched source files
 #              (e.g. org.apache.commons.lang.StringUtils)
 #   newText  - Replacement text/string
 #              (e.g. org.apache.commons.lang3.StringUtils)
@@ -36,6 +36,7 @@ products=$1
 branch=$2
 oldText=$3
 newText=$4
+fileExtension=${5:-java}
 
 # Auto-collect repos if empty
 if [ -z "$products" ]; then
@@ -43,7 +44,7 @@ if [ -z "$products" ]; then
 fi
 
 ORG="axonivy-market"
-WORK_DIR=$(mktemp -d -t replace-import-XXXXXX)
+WORK_DIR=$(mktemp -d -t replace-text-XXXXXX)
 # trap "rm -rf ${WORK_DIR}" EXIT
 
 replaceInProduct() {
@@ -65,7 +66,7 @@ replaceInProduct() {
 
   # Count files containing the old text before replacement
   local match_count
-  match_count=$(grep -rl --include="*.java" "${oldText}" . 2>/dev/null | wc -l)
+  match_count=$(grep -rl --include="*.${fileExtension}" "${oldText}" . 2>/dev/null | wc -l)
 
   if [ "${match_count}" -eq 0 ]; then
     echo "  ℹ No occurrences of '${oldText}' found — skipping"
@@ -74,8 +75,8 @@ replaceInProduct() {
 
   echo "  Found '${oldText}' in ${match_count} file(s) — replacing..."
 
-  # Replace all occurrences in Java source files
-  find . -name "*.java" -exec sed -i "s|${oldText}|${newText}|g" {} +
+  # Replace all occurrences in matched file type
+  find . -name "*.${fileExtension}" -exec sed -i "s|${oldText}|${newText}|g" {} +
 
   echo "  Checking for changes in: $(pwd)"
   if git diff --quiet; then

--- a/replace-text.sh
+++ b/replace-text.sh
@@ -26,8 +26,8 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${DIR}/repo-collector.sh
 
-if [ $# -lt 4 ]; then
-  echo "Usage: $0 [products] <branch> <oldText> <newText>"
+if [ $# -lt 5 ]; then
+  echo "Usage: $0 [products] <branch> <oldText> <newText> [fileExtension] "
   echo "Example: $0 'alfresco-connector' master 'org.apache.commons.lang.StringUtils' 'org.apache.commons.lang3.StringUtils'"
   echo "Example (all repos): $0 '' master 'org.apache.commons.lang.StringUtils' 'org.apache.commons.lang3.StringUtils'"
   exit 1
@@ -46,7 +46,7 @@ fi
 
 ORG="axonivy-market"
 WORK_DIR=$(mktemp -d -t replace-text-XXXXXX)
-# trap "rm -rf ${WORK_DIR}" EXIT
+trap "rm -rf ${WORK_DIR}" EXIT
 
 replaceInProduct() {
   local product=$1

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -39,10 +39,6 @@ updateActions() {
   git commit -m "Update workflow actions to ${tag}"
 }
 
-if [ -z "$releaseBranch" ]; then
-  releaseBranch="release/12.0"
-fi
-
 createReleaseBranch() {
   echo "Create release branch ${releaseBranch}"
   if git ls-remote --heads origin "${releaseBranch}" | grep -q "${releaseBranch}"; then
@@ -71,7 +67,9 @@ downloadEngine
 cloneRepo
 
 cd ${repo}
-createReleaseBranch
+if [ -n "$releaseBranch" ]; then
+  createReleaseBranch
+fi
 branch="raise-to-${convert_to_version}"
 git switch -c $branch
 

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -25,7 +25,7 @@ cloneRepo() {
 }
 
 updateMavenVersion() {
-  artifactVersion $convert_to_version $buildPluginVersion $testerVersion
+  artifactVersion $convert_to_version
 }
 
 commitChanges() {

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -26,6 +26,9 @@ cloneRepo() {
 
 updateMavenVersion() {
   artifactVersion $convert_to_version $buildPluginVersion $testerVersion
+}
+
+commitChanges() {
   # commit changes
   git add .
   git commit -m "Update maven version to ${convert_to_version}"
@@ -72,8 +75,9 @@ fi
 branch="raise-to-${convert_to_version}"
 git switch -c $branch
 
-raiseProject
 updateMavenVersion
+raiseProject
+commitChanges
 updateActions
 push
 cd ..

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -72,7 +72,11 @@ cd ${repo}
 if [ -n "$releaseBranch" ]; then
   createReleaseBranch
 fi
-branch="raise-to-${convert_to_version}"
+if [ -n "$migrationBranch" ]; then
+  branch="$migrationBranch"
+else
+  branch="migrate-to-${convert_to_version}"
+fi
 git switch -c $branch
 
 updateMavenVersion

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -25,8 +25,7 @@ cloneRepo() {
 }
 
 updateMavenVersion() {
-  artifactVersion $convert_to_version
-
+  artifactVersion $convert_to_version $buildPluginVersion $testerVersion
   # commit changes
   git add .
   git commit -m "Update maven version to ${convert_to_version}"

--- a/update-dependency.sh
+++ b/update-dependency.sh
@@ -3,7 +3,7 @@
 # Usage: update-dependency.sh [products] <branch> <module> <groupId> <artifactId> <version>
 #
 # Parameters:
-#   products   - (Optional) Single product name, comma-separated list, or empty to use all repos
+#   products   - Single product name, comma-separated list, or empty to use all repos
 #   branch     - Branch name (e.g. master, release/12.0)
 #   module     - Module name (e.g. idp-connector-demo)
 #   groupId    - Group ID of the dependency (e.g. com.axonivy.market)
@@ -21,7 +21,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${DIR}/repo-collector.sh
 
-if [ $# -lt 4 ]; then
+if [ $# -lt 6 ]; then
   echo "Usage: $0 [products] <branch> <module> <groupId> <artifactId> [version]"
   echo "Example: $0 'idp-connector,market-core' master module com.axonivy.market lib 2.0.0"
   echo "Example (no version): $0 'idp-connector,market-core' master module com.axonivy.market lib"

--- a/update-dependency.sh
+++ b/update-dependency.sh
@@ -24,7 +24,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ $# -lt 4 ]; then
   echo "Usage: $0 [products] <branch> <module> <groupId> <artifactId> [version]"
   echo "Example: $0 'idp-connector,market-core' master module com.axonivy.market lib 2.0.0"
-  echo "Example (latest): $0 'idp-connector,market-core' master module com.axonivy.market lib"
+  echo "Example (no version): $0 'idp-connector,market-core' master module com.axonivy.market lib"
   exit 1
 fi
 
@@ -42,13 +42,15 @@ fi
 
 ORG="axonivy-market"
 WORK_DIR=$(mktemp -d -t update-dep-XXXXXX)
-trap "rm -rf ${WORK_DIR}" EXIT
+# trap "rm -rf ${WORK_DIR}" EXIT
 
 updateProduct() {
   local product=$1
-  local repo_url="git@github.com:${ORG}/${product}.git"
+  local repo_url="https://github.com/${ORG}/${product}.git"
   
   echo "→ ${product}"
+  echo "  URL: ${repo_url}"
+  echo "  Branch: ${branch}"
   cd "${WORK_DIR}"
   
   if ! git clone -b "${branch}" "${repo_url}" "${product}" 2>/dev/null; then
@@ -57,45 +59,60 @@ updateProduct() {
   fi
   
   cd "${product}"
+  echo "  Cloned to: $(pwd)"
   
   if [ ! -d "${project}" ]; then
-    echo "  ❌ Module not found"
+    echo "  ❌ Module not found: ${project}"
+    echo "  Available dirs: $(ls -d */ 2>/dev/null | tr '\n' ' ')"
     return 1
   fi
   
   cd "${project}"
+  echo "  Running Maven in: $(pwd)"
   if [ -z "$version" ]; then
-    if ! mvn -B versions:use-dep-version \
-      -Dincludes="${groupId}:${artifactId}" \
-      -DforceVersion=true > /dev/null 2>&1; then
-      echo "  ❌ Update failed"
-      return 1
+    echo "  Adding dependency: ${groupId}:${artifactId} (no version tag)"
+    # Check if dependency already exists
+    if grep -q "<groupId>${groupId}</groupId>" pom.xml && grep -q "<artifactId>${artifactId}</artifactId>" pom.xml; then
+      # Exists: remove version tag if present
+      sed -i "/<groupId>${groupId}<\/groupId>/,/<\/dependency>/{ /<version>.*<\/version>/d; }" pom.xml
+    else
+      # Doesn't exist: add new dependency block without version
+      sed -i "/<\/dependencies>/i\\    <dependency>\\n      <groupId>${groupId}</groupId>\\n      <artifactId>${artifactId}</artifactId>\\n    </dependency>" pom.xml
     fi
   else
-    if ! mvn -B versions:use-dep-version \
+    echo "  Updating to: ${groupId}:${artifactId}:${version}"
+    mvn -B versions:use-dep-version \
       -Dincludes="${groupId}:${artifactId}" \
       -DdepVersion="${version}" \
-      -DforceVersion=true > /dev/null 2>&1; then
+      -DforceVersion=true
+    if [ $? -ne 0 ]; then
       echo "  ❌ Update failed"
       return 1
     fi
   fi
   
   cd "${WORK_DIR}/${product}"
+  echo "  Checking for changes in: $(pwd)"
   if git diff --quiet; then
-    echo "  ℹ No changes"
+    echo "  ℹ No changes detected"
+    git status --short
     return 0
   fi
+  
+  echo "  Found changes:"
+  git diff --name-only
+  echo "  Staging and committing..."
 
   git add .
-  git commit -m "Update ${groupId}:${artifactId}${version:+ to $version}"
+  git commit -m "Add ${groupId}:${artifactId}${version:+ version $version}"
+  echo "  Commit: $(git log -1 --oneline)"
   
   if ! git push origin "HEAD:${branch}" 2>/dev/null; then
     echo "  ❌ Push failed"
     return 1
   fi
   
-  echo "  ✓ Updated"
+  echo "  ✓ Added and pushed"
 }
 
 echo "Updating: ${groupId}:${artifactId}${version:+ to $version}"

--- a/update-dependency.sh
+++ b/update-dependency.sh
@@ -42,7 +42,7 @@ fi
 
 ORG="axonivy-market"
 WORK_DIR=$(mktemp -d -t update-dep-XXXXXX)
-# trap "rm -rf ${WORK_DIR}" EXIT
+trap "rm -rf ${WORK_DIR}" EXIT
 
 updateProduct() {
   local product=$1
@@ -81,13 +81,20 @@ updateProduct() {
     fi
   else
     echo "  Updating to: ${groupId}:${artifactId}:${version}"
-    mvn -B versions:use-dep-version \
-      -Dincludes="${groupId}:${artifactId}" \
-      -DdepVersion="${version}" \
-      -DforceVersion=true
-    if [ $? -ne 0 ]; then
-      echo "  ❌ Update failed"
-      return 1
+    if ! grep -q "<artifactId>${artifactId}</artifactId>" pom.xml; then
+      # Dependency does not exist yet — add it directly with version via sed
+      echo "  Dependency not in pom.xml yet, adding new block..."
+      sed -i "/<\/dependencies>/i\\    <dependency>\\n      <groupId>${groupId}</groupId>\\n      <artifactId>${artifactId}</artifactId>\\n      <version>${version}</version>\\n    </dependency>" pom.xml
+    else
+      # Dependency exists — use Maven to update the version
+      mvn -B versions:use-dep-version \
+        -Dincludes="${groupId}:${artifactId}" \
+        -DdepVersion="${version}" \
+        -DforceVersion=true
+      if [ $? -ne 0 ]; then
+        echo "  ❌ Update failed"
+        return 1
+      fi
     fi
   fi
   

--- a/update-dependency.sh
+++ b/update-dependency.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Usage: update-dependency.sh [products] <branch> <module> <groupId> <artifactId> <version>
+#
+# Parameters:
+#   products   - (Optional) Single product name, comma-separated list, or empty to use all repos
+#   branch     - Branch name (e.g. master, release/12.0)
+#   module     - Module name (e.g. idp-connector-demo)
+#   groupId    - Group ID of the dependency (e.g. com.axonivy.market)
+#   artifactId - Artifact ID of the dependency (e.g. market-core)
+#   version    - Version of the dependency (e.g. 1.0.0)
+#
+# Examples:
+#   update-dependency.sh idp-connector master idp-connector-demo com.axonivy.market market-core 1.0.0
+#   update-dependency.sh "idp-connector,market-core" master module-name com.axonivy.market market-lib 2.0.0
+#   update-dependency.sh "" master module-name com.axonivy.market market-lib 2.0.0  (all repos)
+#
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. ${DIR}/repo-collector.sh
+
+if [ $# -lt 4 ]; then
+  echo "Usage: $0 [products] <branch> <module> <groupId> <artifactId> [version]"
+  echo "Example: $0 'idp-connector,market-core' master module com.axonivy.market lib 2.0.0"
+  echo "Example (latest): $0 'idp-connector,market-core' master module com.axonivy.market lib"
+  exit 1
+fi
+
+products=$1
+branch=$2
+project=$3
+groupId=$4
+artifactId=$5
+version=$6
+
+# Auto-collect repos if empty
+if [ -z "$products" ]; then
+  products=$(collectRepos | tr '\n' ',' | sed 's/,$//')
+fi
+
+ORG="axonivy-market"
+WORK_DIR=$(mktemp -d -t update-dep-XXXXXX)
+trap "rm -rf ${WORK_DIR}" EXIT
+
+updateProduct() {
+  local product=$1
+  local repo_url="git@github.com:${ORG}/${product}.git"
+  
+  echo "→ ${product}"
+  cd "${WORK_DIR}"
+  
+  if ! git clone -b "${branch}" "${repo_url}" "${product}" 2>/dev/null; then
+    echo "  ❌ Clone failed"
+    return 1
+  fi
+  
+  cd "${product}"
+  
+  if [ ! -d "${project}" ]; then
+    echo "  ❌ Module not found"
+    return 1
+  fi
+  
+  cd "${project}"
+  if [ -z "$version" ]; then
+    if ! mvn -B versions:use-dep-version \
+      -Dincludes="${groupId}:${artifactId}" \
+      -DforceVersion=true > /dev/null 2>&1; then
+      echo "  ❌ Update failed"
+      return 1
+    fi
+  else
+    if ! mvn -B versions:use-dep-version \
+      -Dincludes="${groupId}:${artifactId}" \
+      -DdepVersion="${version}" \
+      -DforceVersion=true > /dev/null 2>&1; then
+      echo "  ❌ Update failed"
+      return 1
+    fi
+  fi
+  
+  cd "${WORK_DIR}/${product}"
+  if git diff --quiet; then
+    echo "  ℹ No changes"
+    return 0
+  fi
+
+  git add .
+  git commit -m "Update ${groupId}:${artifactId}${version:+ to $version}"
+  
+  if ! git push origin "HEAD:${branch}" 2>/dev/null; then
+    echo "  ❌ Push failed"
+    return 1
+  fi
+  
+  echo "  ✓ Updated"
+}
+
+echo "Updating: ${groupId}:${artifactId}${version:+ to $version}"
+echo "Branch: ${branch} | Module: ${project}"
+echo ""
+
+IFS=',' read -ra product_list <<< "$products"
+for product in "${product_list[@]}"; do
+  product=$(echo "$product" | xargs)
+  [ -z "$product" ] && continue
+  updateProduct "$product" || true
+done

--- a/update-dependency.sh
+++ b/update-dependency.sh
@@ -44,6 +44,22 @@ ORG="axonivy-market"
 WORK_DIR=$(mktemp -d -t update-dep-XXXXXX)
 trap "rm -rf ${WORK_DIR}" EXIT
 
+# Remove <version> element from a matching dependency in pom.xml
+deleteVersionIfPresent() {
+  local groupId="$1"; local artifactId="$2"
+  if command -v xmlstarlet >/dev/null 2>&1; then
+    xmlstarlet ed -P -L -d "/project/dependencies/dependency[groupId='${groupId}' and artifactId='${artifactId}']/version" pom.xml
+  else
+    perl -0777 -pe 's{(<dependency>.*?<groupId>'"${groupId}"'</groupId>.*?<artifactId>'"${artifactId}"'</artifactId>.*?)(<version>.*?</version>[ \t\r\n]*)}{\1}gs' -i pom.xml
+  fi
+}
+
+updateVersionWithMaven() {
+  local groupId="$1"; local artifactId="$2"; local version="$3"
+  mvn -B versions:use-dep-version -DgenerateBackupPoms=false  -Dincludes="${groupId}:${artifactId}" \
+    -DdepVersion="${version}" -DforceVersion=true
+}
+
 updateProduct() {
   local product=$1
   local repo_url="https://github.com/${ORG}/${product}.git"
@@ -74,24 +90,20 @@ updateProduct() {
     # Check if dependency already exists
     if grep -q "<groupId>${groupId}</groupId>" pom.xml && grep -q "<artifactId>${artifactId}</artifactId>" pom.xml; then
       # Exists: remove version tag if present
-      sed -i "/<groupId>${groupId}<\/groupId>/,/<\/dependency>/{ /<version>.*<\/version>/d; }" pom.xml
+      deleteVersionIfPresent "${groupId}" "${artifactId}"
     else
-      # Doesn't exist: add new dependency block without version
+      # Not exist: add new dependency block without version
       sed -i "/<\/dependencies>/i\\    <dependency>\\n      <groupId>${groupId}</groupId>\\n      <artifactId>${artifactId}</artifactId>\\n    </dependency>" pom.xml
     fi
   else
     echo "  Updating to: ${groupId}:${artifactId}:${version}"
     if ! grep -q "<artifactId>${artifactId}</artifactId>" pom.xml; then
-      # Dependency does not exist yet — add it directly with version via sed
+      # Not exist: add directly with version via sed
       echo "  Dependency not in pom.xml yet, adding new block..."
       sed -i "/<\/dependencies>/i\\    <dependency>\\n      <groupId>${groupId}</groupId>\\n      <artifactId>${artifactId}</artifactId>\\n      <version>${version}</version>\\n    </dependency>" pom.xml
     else
-      # Dependency exists — use Maven to update the version
-      mvn -B versions:use-dep-version \
-        -Dincludes="${groupId}:${artifactId}" \
-        -DdepVersion="${version}" \
-        -DforceVersion=true
-      if [ $? -ne 0 ]; then
+      # Exists: try to update via Maven
+      if ! updateVersionWithMaven "${groupId}" "${artifactId}" "${version}"; then
         echo "  ❌ Update failed"
         return 1
       fi


### PR DESCRIPTION
Migrate (all) repo(s) to 14.0.0-SNAPSHOT (sprint release in this stage). Scope:
- update build.plugin.version & tester.version to version from user input.
- update all pom version before migrate to v14 to avoid conflict with parent version which is mentioned in [#1](https://github.com/mojohaus/versions/issues/498) [#2](https://github.com/mojohaus/versions/issues/1042) [#3](https://github.com/axonivy-market/market-up2date-keeper/actions/runs/25665109147/job/75335448860)
- update all link/version in migrating to 14
- update logic of create branch -> only create release if we migrate mater from LTS -> later release version (e.g. 13.0, 15.0)