### PR TITLE
Feat: Update target branch when cloning repo

### DIFF
--- a/.github/workflows/raise-products.yml
+++ b/.github/workflows/raise-products.yml
@@ -29,6 +29,10 @@ on:
         description: 'Name of the release branch to create (e.g. "release/13.0"). Only used when "createReleaseBranch" is true.'
         required: false
         default: 'release/13.0'
+      targetBranch:
+        description: 'Target branch of the product repositories to raise from.'
+        required: false
+        default: 'master'
       javaVersion:
         description: 'Java version to use for the migration (e.g. "25")'
         required: false
@@ -66,6 +70,7 @@ jobs:
           export engineUrl=${{ inputs.engineUrl }}
           export releaseBranch=${{ inputs.createReleaseBranch == true && inputs.releaseBranch || '' }}
           export migrationBranch=${{ inputs.migrationBranch }}
+          export targetBranch=${{ inputs.targetBranch }}
           echo "workDir=$(pwd)" >> $GITHUB_ENV
           ./raise-all-market-products.sh ${{ inputs.version }} ${{ inputs.product }}
         shell: bash

--- a/project-migrator.sh
+++ b/project-migrator.sh
@@ -34,7 +34,7 @@ raiseProject() {
     ${workDir}/engine/bin/EngineConfigCli migrate-project ${projects[@]}
 
     git add . #include new+moved files!
-    git commit -m "Raise project to ${convert_to_version}"
+    git commit -m "Chore: Raise project to ${convert_to_version}"
   else
     echo "No projects found in ${gitDir}"
   fi

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -20,7 +20,7 @@ checkRepoExists() {
 
 cloneRepo() {
   if ! [ -d "${repo}" ]; then
-    gh repo clone "${repo_url}"
+    gh repo clone "${repo_url}" -- -b "${targetBranch}"
   fi
 }
 
@@ -31,14 +31,14 @@ updateMavenVersion() {
 commitChanges() {
   # commit changes
   git add .
-  git commit -m "Update maven version to ${convert_to_version}"
+  git commit -m "Chore: Update project version to ${convert_to_version}"
 }
 
 updateActions() {
   tag="v6"
   updateWorkflows "${tag}"
   git add .
-  git commit -m "Update workflow actions to ${tag}"
+  git commit -m "CI: Update workflow actions to ${tag}"
 }
 
 createReleaseBranch() {
@@ -58,7 +58,7 @@ push() {
   else
     echo "Pushing changes of ${repo_name}"
     git push --set-upstream origin $branch
-    gh pr create --title "Migrate to ${convert_to_version} :camel:" --assignee "$GITHUB_ACTOR" --body "A friendly conversion provided by market-up2date-keeper :robot: :handshake: "
+    gh pr create --head $branch --base ${targetBranch} --title "Migrate to ${convert_to_version} :camel:" --assignee "$GITHUB_ACTOR" --body "A friendly conversion provided by market-up2date-keeper :robot: :handshake: "
     echo "${repo_url}" >> ${workDir}/migrated-repos.txt
   fi
 }

--- a/repo-migrator.sh
+++ b/repo-migrator.sh
@@ -69,6 +69,8 @@ downloadEngine
 cloneRepo
 
 cd ${repo}
+currentBranch="$(git branch --show-current)"
+echo "Current Git branch: ${currentBranch}"
 if [ -n "$releaseBranch" ]; then
   createReleaseBranch
 fi


### PR DESCRIPTION
Enhance monitoring for 14.0: provide input for source branch of migration -> user can choose 'dev/14,0' or even 'master' branch to make it up2date with latest snapshot version